### PR TITLE
Include extra payments, vacations & company info in payroll export

### DIFF
--- a/Backend/controllers/TransaksiController.js
+++ b/Backend/controllers/TransaksiController.js
@@ -651,6 +651,7 @@ export const getDataGajiPegawai = async (year, month) => {
     const paramNPIS = await Parameter.findOne({ where: { type: "NPIS" } });
     const paramCCTS = await Parameter.findOne({ where: { type: "CCTS" } });
     const paramCOMP = await Parameter.findOne({ where: { type: "COMP" } });
+    const paramADCO = await Parameter.findOne({ where: { type: "ADCO" } });
 
     const salariosConDeducciones = await Promise.all(
       attendance.map(async (attendanceEmployee) => {
@@ -819,6 +820,7 @@ export const getDataGajiPegawai = async (year, month) => {
           numeroPatronalISSS: paramNPIS?.value,
           correlativoCentroTrabajoISSS: paramCCTS?.value,
           nombreEmpresa: paramCOMP?.value,
+          ubicacionEmpresa: paramADCO?.value,
 
           // Fechas
           year: attendanceEmployee.tahun,
@@ -869,6 +871,7 @@ export const getDataGajiPegawaiById = async (attendanceId) => {
     const paramNPIS = await Parameter.findOne({ where: { type: "NPIS" } });
     const paramCCTS = await Parameter.findOne({ where: { type: "CCTS" } });
     const paramCOMP = await Parameter.findOne({ where: { type: "COMP" } });
+    const paramADCO = await Parameter.findOne({ where: { type: "ADCO" } });
 
     // Procesar asistencia individual
     const attDate = new Date(att.tahun, parseInt(att.bulan, 10) - 1, att.day);
@@ -1018,6 +1021,7 @@ export const getDataGajiPegawaiById = async (attendanceId) => {
       numeroPatronalISSS: paramNPIS?.value,
       correlativoCentroTrabajoISSS: paramCCTS?.value,
       nombreEmpresa: paramCOMP?.value,
+      ubicacionEmpresa: paramADCO?.value,
 
       // Fechas
       year: att.tahun,

--- a/Backend/controllers/TransaksiController.js
+++ b/Backend/controllers/TransaksiController.js
@@ -749,10 +749,12 @@ export const getDataGajiPegawai = async (year, month) => {
             const totalPayments = totalPaymentsInMonth?.value || -1;
             const payment_frequency = deduction?.payment_frequency || 0;
 
+            const upperBound = until === -1 ? Infinity : until;
+
             if (
-              salarioStandarRestante > from &&
-              (until < 0 || salarioStandarRestante <= until) &&
-              (payment_frequency === totalPayments || payment_frequency === -1)
+              salarioStandarRestante > from && // mayor que el mínimo
+              salarioStandarRestante <= upperBound && // dentro del tope (o sin tope)
+              (payment_frequency == totalPayments || payment_frequency == -1) // coincide freq.
             ) {
               const baseGravable = salarioStandarRestante - from;
 
@@ -948,10 +950,12 @@ export const getDataGajiPegawaiById = async (attendanceId) => {
         const totalPayments = totalPaymentsInMonth?.value || -1;
         const payment_frequency = deduction?.payment_frequency || 0;
 
+        const upperBound = until == -1 ? Infinity : until;
+        
         if (
-          salarioStandarRestante > from &&
-          (until < 0 || salarioStandarRestante <= until) &&
-          (payment_frequency === totalPayments || payment_frequency === -1)
+          salarioStandarRestante > from && // mayor que el mínimo
+          salarioStandarRestante <= upperBound && // dentro del tope (o sin tope)
+          (payment_frequency == totalPayments || payment_frequency == "-1") // coincide freq.
         ) {
           const baseGravable = salarioStandarRestante - from;
 

--- a/Backend/db/db_scripts_2.sql
+++ b/Backend/db/db_scripts_2.sql
@@ -18,10 +18,10 @@ TRUNCATE potongan_gaji;
 INSERT INTO potongan_gaji
   (potongan, jml_potongan, `from`, `until`, value_d, type, createdAt, updatedAt, payment_frequency, deduction_group)
 VALUES
-  ('I Tramo',   0.000,  0.01,  137.50, 0.00, 'DIN', NOW(), NOW(), 1, 'Remuneraciones semanales'),
-  ('II Tramo', 0.1000, 137.51, 223.81, 4.42, 'DIN', NOW(), NOW(), 1, 'Remuneraciones semanales'),
-  ('III Tramo',0.2000, 223.82, 509.52,15.00, 'DIN', NOW(), NOW(), 1, 'Remuneraciones semanales'),
-  ('IV Tramo', 0.3000, 509.53,  -1,  72.14, 'DIN', NOW(), NOW(), 1, 'Remuneraciones semanales');
+  ('I Tramo',   0.000,  0.01,  137.50, 0.00, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales'),
+  ('II Tramo', 0.1000, 137.51, 223.81, 4.42, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales'),
+  ('III Tramo',0.2000, 223.82, 509.52,15.00, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales'),
+  ('IV Tramo', 0.3000, 509.53,  -1,  72.14, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales');
 
 -- 2) Remuneraciones quincenales (payment_frequency = 2)
 INSERT INTO potongan_gaji
@@ -36,10 +36,10 @@ VALUES
 INSERT INTO potongan_gaji
   (potongan, jml_potongan, `from`, `until`, value_d, type, createdAt, updatedAt, payment_frequency, deduction_group)
 VALUES
-  ('I Tramo',   0.000,    0.01,  550.00,   0.00, 'DIN', NOW(), NOW(), 4, 'Remuneraciones mensuales'),
-  ('II Tramo', 0.1000, 550.01,  895.24,  17.67, 'DIN', NOW(), NOW(), 4, 'Remuneraciones mensuales'),
-  ('III Tramo',0.2000, 895.25, 2038.10,  60.00, 'DIN', NOW(), NOW(), 4, 'Remuneraciones mensuales'),
-  ('IV Tramo', 0.3000,2038.11,    -1, 288.57, 'DIN', NOW(), NOW(), 4, 'Remuneraciones mensuales');
+  ('I Tramo',   0.000,    0.01,  550.00,   0.00, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales'),
+  ('II Tramo', 0.1000, 550.01,  895.24,  17.67, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales'),
+  ('III Tramo',0.2000, 895.25, 2038.10,  60.00, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales'),
+  ('IV Tramo', 0.3000,2038.11,    -1, 288.57, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales');
 
 -- Aportaciones legales (pago mensual)
 INSERT INTO potongan_gaji

--- a/Backend/db/db_scripts_3.sql
+++ b/Backend/db/db_scripts_3.sql
@@ -15,3 +15,41 @@ INSERT INTO parameters (id, name, value, value_type, type) VALUES
   (5, 'Número patronal ISSS',              '12345678',        'STRING', 'NPIS'),
   (6, 'Correlativo Centro de Trabajo ISSS','876543',          'INT',    'CCTS'),
   (7, 'Nombre de la empresa',              'AdventureWorks S.A.','STRING','COMP');
+
+
+TRUNCATE potongan_gaji;
+
+-- 1) Remuneraciones semanales (payment_frequency = 1)
+INSERT INTO potongan_gaji
+  (potongan, jml_potongan, `from`, `until`, value_d, type, createdAt, updatedAt, payment_frequency, deduction_group)
+VALUES
+  ('I Tramo',   0.000,  0.01,  137.50, 0.00, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales'),
+  ('II Tramo', 0.1000, 137.51, 223.81, 4.42, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales'),
+  ('III Tramo',0.2000, 223.82, 509.52,15.00, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales'),
+  ('IV Tramo', 0.3000, 509.53,  -1,  72.14, 'DIN', NOW(), NOW(), 4, 'Remuneraciones semanales');
+
+-- 2) Remuneraciones quincenales (payment_frequency = 2)
+INSERT INTO potongan_gaji
+  (potongan, jml_potongan, `from`, `until`, value_d, type, createdAt, updatedAt, payment_frequency, deduction_group)
+VALUES
+  ('I Tramo',   0.000,   0.01,  275.00, 0.00,  'DIN', NOW(), NOW(), 2, 'Remuneraciones quincenales'),
+  ('II Tramo', 0.1000, 275.01, 447.62, 8.83,  'DIN', NOW(), NOW(), 2, 'Remuneraciones quincenales'),
+  ('III Tramo',0.2000, 447.63,1019.05,30.00, 'DIN', NOW(), NOW(), 2, 'Remuneraciones quincenales'),
+  ('IV Tramo', 0.3000,1019.06,   -1,144.28, 'DIN', NOW(), NOW(), 2, 'Remuneraciones quincenales');
+
+-- 3) Remuneraciones mensuales (payment_frequency = 4)
+INSERT INTO potongan_gaji
+  (potongan, jml_potongan, `from`, `until`, value_d, type, createdAt, updatedAt, payment_frequency, deduction_group)
+VALUES
+  ('I Tramo',   0.000,    0.01,  550.00,   0.00, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales'),
+  ('II Tramo', 0.1000, 550.01,  895.24,  17.67, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales'),
+  ('III Tramo',0.2000, 895.25, 2038.10,  60.00, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales'),
+  ('IV Tramo', 0.3000,2038.11,    -1, 288.57, 'DIN', NOW(), NOW(), 1, 'Remuneraciones mensuales');
+
+  -- Aportaciones legales (pago mensual)
+INSERT INTO potongan_gaji
+  (potongan, jml_potongan, type, createdAt, updatedAt, payment_frequency, deduction_group)
+VALUES
+  ('ISSS',      0.0300, 'STA', NOW(), NOW(), 4, 'Deducciones mayo 2025'),
+  ('AFP',       0.0725, 'STA', NOW(), NOW(), 4, 'Deducciones mayo 2025');
+-- ('INSAFORP',  0.0100, 'STA', NOW(), NOW(), 4, 'Deducciones mayo 2025')

--- a/Backend/db/db_scripts_3.sql
+++ b/Backend/db/db_scripts_3.sql
@@ -14,7 +14,8 @@ INSERT INTO parameters (id, name, value, value_type, type) VALUES
   (4, 'DUI/NIT del Empleador',             '0614200595',      'STRING', 'DUIN'),
   (5, 'Número patronal ISSS',              '12345678',        'STRING', 'NPIS'),
   (6, 'Correlativo Centro de Trabajo ISSS','876543',          'INT',    'CCTS'),
-  (7, 'Nombre de la empresa',              'AdventureWorks S.A.','STRING','COMP');
+  (7, 'Nombre de la empresa',              'AdventureWorks S.A.','STRING','COMP'),
+  (8, 'Ubicación de la empresa',           'Acajutla, Sonsonate','STRING','ADCO');
 
 
 TRUNCATE potongan_gaji;

--- a/Frontend/src/assets/locales/en/print.json
+++ b/Frontend/src/assets/locales/en/print.json
@@ -25,5 +25,8 @@
   "observations": "OBSERVATIONS",
   "accounting": "ACCOUNTING",
   "audit": "AUDIT",
-  "loading": "Loading..."
+  "loading": "Loading...",
+  "extraPayments": "Extra payments",
+  "vacationPayments": "Vacations",
+  "absencesPenalty": "Penalty for absences"
 }

--- a/Frontend/src/assets/locales/es/print.json
+++ b/Frontend/src/assets/locales/es/print.json
@@ -25,5 +25,8 @@
   "observations": "OBSERVACIONES",
   "accounting": "CONTABILIDAD",
   "audit": "AUDITORIA",
-  "loading": "Cargando..."
+  "loading": "Cargando...",
+  "extraPayments": "Pagos extra",
+  "vacationPayments": "Vacaciones",
+  "absencesPenalty": "Penalización por ausencias"
 }

--- a/Frontend/src/assets/locales/id/print.json
+++ b/Frontend/src/assets/locales/id/print.json
@@ -25,5 +25,8 @@
   "observations": "CATATAN",
   "accounting": "AKUNTANSI",
   "audit": "AUDIT",
-  "loading": "Memuat..."
+  "loading": "Memuat...",
+  "extraPayments": "Pembayaran Tambahan (lembur, bonus, dll.)",
+  "vacationPayments": "Liburan yang Dibayar",
+  "absencesPenalty": "Penalti karena Ketidakhadiran"
 }

--- a/Frontend/src/components/molecules/PrintPdf/PrintPdfBoleta/index.jsx
+++ b/Frontend/src/components/molecules/PrintPdf/PrintPdfBoleta/index.jsx
@@ -7,6 +7,7 @@ import { useDisplayValue } from "../../../../hooks/useDisplayValue";
 import useCurrencyByUser from "../../../../config/currency/useCurrencyByUser";
 
 import { API_URL } from "@/config/env";
+import { ButtonOne } from "../../../atoms";
 
 const PrintPdfBoleta = () => {
   const componentRef = useRef();
@@ -28,15 +29,17 @@ const PrintPdfBoleta = () => {
         setParametros(res.data);
 
         const pmon = res.data.find((p) => p.type === "PMON");
+
+        console.log("pmon.value", pmon.value)
         if (pmon) {
           switch (pmon.value) {
-            case 1:
+            case "1":
               setTipoBoleta("boleta_mensual");
               break;
-            case 2:
+            case "1":
               setTipoBoleta("boleta_quincenal");
               break;
-            case 4:
+            case "1":
               setTipoBoleta("boleta_semanal");
               break;
             default:
@@ -97,8 +100,11 @@ const PrintPdfBoleta = () => {
 
   return (
     <div>
-      <button onClick={handlePrint}>{t("print")}</button>
+      <div className="flex gap-3 bg-white p-6 text-center dark:bg-meta-4">
+        <ButtonOne onClick={handlePrint}>{t("print")}</ButtonOne>
+      </div>
 
+      <br />
       <div
         ref={componentRef}
         style={{
@@ -112,7 +118,9 @@ const PrintPdfBoleta = () => {
         <div style={{ textAlign: "right" }}>
           {t("receiptNumber")}: <strong>____________________</strong>
         </div>
-        <h3 style={{ textAlign: "center" }}>{t("receivedFrom")}</h3>
+        <h3 style={{ textAlign: "left" }}>
+          {t("receivedFrom")} <strong>{data.nombreEmpresa}</strong>
+        </h3>
         <p>
           {t("concept")}: <strong>{getDisplayValue(tipoBoleta)}</strong>
         </p>
@@ -141,7 +149,7 @@ const PrintPdfBoleta = () => {
               </td>
             </tr>
             <tr>
-              <td>{t("extraHours")}</td>
+              <td>{t("extraPayments")}</td>
               <td>{symbol} -</td>
               <td>{t("isr")}</td>
               <td>
@@ -149,19 +157,32 @@ const PrintPdfBoleta = () => {
                 {toLocal(totalRenta)}
               </td>
             </tr>
+
+            <tr>
+              <td>{t("vacationPayments")}</td>
+              <td>{symbol} -</td>
+              <td>{t("totalDeductions")}</td>
+              <td>
+                {symbol}
+                {toLocal(totalDeducciones)}
+              </td>
+            </tr>
+
+            <tr>
+              <td>( - ) {t("absencesPenalty")}</td>
+              <td>{symbol} -</td>
+              <td></td>
+              <td></td>
+            </tr>
+
             <tr>
               <td>( - ) {t("totalDeductions")}</td>
               <td>
                 {symbol}
                 {toLocal(data.totalDeductions)}
               </td>
-              {/* <td>{t("otherDiscounts")}</td>
-              <td>$ -</td> */}
-              <td>{t("totalDeductions")}</td>
-              <td>
-                {symbol}
-                {toLocal(totalDeducciones)}
-              </td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <td>
@@ -196,7 +217,7 @@ const PrintPdfBoleta = () => {
         </table>
 
         <p>
-          {t("placeDate")}: San Salvador, {fechaFormateada}
+          {t("placeDate")}: {data.ubicacionEmpresa}, {fechaFormateada}
         </p>
 
         <div
@@ -239,6 +260,8 @@ const PrintPdfBoleta = () => {
           </div>
         </div>
       </div>
+
+      <br />
     </div>
   );
 };

--- a/Frontend/src/components/molecules/PrintPdf/PrintPdfBoleta/index.jsx
+++ b/Frontend/src/components/molecules/PrintPdf/PrintPdfBoleta/index.jsx
@@ -36,10 +36,10 @@ const PrintPdfBoleta = () => {
             case "1":
               setTipoBoleta("boleta_mensual");
               break;
-            case "1":
+            case "2":
               setTipoBoleta("boleta_quincenal");
               break;
-            case "1":
+            case "4":
               setTipoBoleta("boleta_semanal");
               break;
             default:
@@ -138,7 +138,7 @@ const PrintPdfBoleta = () => {
               </td>
               <td>
                 {symbol}
-                {toLocal(data.gaji_pokok)}
+                {toLocal(data.salarioBruto)}
               </td>
               <td>
                 <strong>{t("isss")}</strong>


### PR DESCRIPTION
This PR fixes an issue where the exported payroll file was missing:
- Extra payments  
- Vacation data (days and amounts)  
- Company location  
- Company name  

The export routine has been updated to pull and include these fields in the generated CSV/Excel.

## Screenshots 

*Before fix:* missing  info  

![image](https://github.com/user-attachments/assets/2ba82896-42b8-4212-8aeb-49d9ed27c8ee)

*After fix:* all fields present  

![image](https://github.com/user-attachments/assets/31f0d106-cb37-4114-b399-c162981be2bf)

